### PR TITLE
Pass options from callers directly to gulp-compass after merging with defaults.

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,17 +31,8 @@ elixir.extend("compass", function(src, outputDir, options) {
 
     gulp.task('compass', function() {
         return gulp.src(src)
-            .pipe(compass({
-                require: options.modules,
-                config_file: options.config_file,
-                style: options.style,
-                css: options.css,
-                sass: options.sass,
-                font: options.font,
-                image: options.image,
-                javascript: options.js,
-                sourcemap: options.sourcemap
-            })).on('error', onError)
+            .pipe(compass(options))
+            .on('error', onError)
             .pipe(new Notification().message('Compass Compiled!'));
     });
 


### PR DESCRIPTION
Index.js line 23 merges the user supplied defaults with some internal defaults. But when calling 'gulp-compass' on line 33, it explicitly passes on certain fields, effectively dropping everything else from the caller supplied options array.

This is a problem if the user pulls in some scss files from another source (ex: bootstrap via bower) and needs to specify "import_path" for gulp-compass to pass on to compass.
